### PR TITLE
Update dataset download links

### DIFF
--- a/2019/readme.md
+++ b/2019/readme.md
@@ -118,7 +118,9 @@ id,animal_class
 The `id` column corresponds to the test image id. The `animal_class` is an integer value that indicates the class of the animal, or `0` to represent the absence of an animal.
 
 ## Data
-Download the dataset files here:
+The original competition dataset files are unfortunately no longer accessible. Please see the [iWildCam 2022 page on lila.science](https://lila.science/datasets/iwildcam-2022/) for iWildCam 2022 competition download links.
+
+The original dataset files were once accessible here:
   * CCT images and annotations 87GB zipped
     * [Download Link](https://lilablobssc.blob.core.windows.net/iwildcam2019/iWildCam_2019_CCT.tar.gz)
       * Running `md5sum iWildCam_2019_CCT.tar.gz` should produce `21323ae381653240ff21768658cc44df`

--- a/2020/readme.md
+++ b/2020/readme.md
@@ -93,7 +93,9 @@ id,animal_class
 The `id` column corresponds to the test image id. The `animal_class` is an integer value that indicates the class of the animal, or `0` to represent the absence of an animal.
 
 ## Data
-Download the dataset files here:
+The original competition dataset files are unfortunately no longer accessible. Please see the [iWildCam 2022 page on lila.science](https://lila.science/datasets/iwildcam-2022/) for iWildCam 2022 competition download links.
+
+The original dataset files were once accessible here:
   * WCS training images (84GB zipped)
     * [Download Link](https://lilablobssc.blob.core.windows.net/iwildcam2020/iwildcam2020/train.zip)
       * Running `md5sum train.zip` should produce `881d703639ce1df034e32fee1222bdcb`

--- a/2021/readme.md
+++ b/2021/readme.md
@@ -98,7 +98,9 @@ Id,Predicted2,Predicted3,[...],Predicted571
 The `Id` column corresponds to the test sequence id. `Predicted2` holds an integer value that indicates the number of individuals of species 2 in each test sequence. If you predict there are no animals in the sequence, the entire row after the sequence ID should be populated with `0` values.
 
 ## Data
-Download the dataset files here:
+The original competition dataset files are unfortunately no longer accessible. Please see the [iWildCam 2022 page on lila.science](https://lila.science/datasets/iwildcam-2022/) for iWildCam 2022 competition download links.
+
+The original dataset files were once accessible here:
   * WCS training images (84GB zipped)
     * [Download Link](https://lilablobssc.blob.core.windows.net/iwildcam2020/iwildcam2021/train.zip)
       * Running `md5sum train.zip` should produce `8c1c8e4bc699c16072ea0ff31ce7967a`

--- a/readme.md
+++ b/readme.md
@@ -90,33 +90,7 @@ By downloading iNaturalist data, you agree to the terms outlined by [iNaturalist
 
 Here are the dataset files for this competition:
 
-* WCS training images (84GB zipped)
-  * [Download link](https://lilablobssc.blob.core.windows.net/iwildcam/iwildcam-2022-train.zip)
-    * Running `md5sum iwildcam-2022-train.zip` should produce `8c746de9ded99310832c5ab34438f9e5`
-* WCS test images (25GB zipped)
-  * [Download link](https://lilablobssc.blob.core.windows.net/iwildcam/iwildcam-2022-test.zip)
-    * Running `md5sum iwildcam-2022-test.zip` should produce `4c119e218545ea4374c65c7a2d0264b2`
-* WCS annotations, obfuscated GPS coordinates and MegaDetector v4 detections
-  * [Download link](https://lilablobssc.blob.core.windows.net/iwildcam/iwildcam-2022-metadata.zip)
-    * Running `md5sum iwildcam-2022-metadata.zip` should produce `4fdbfda1d1f909e5e3528a98e17f4629`
-* DeepMAC segmentation masks on MegaDetector v4 detections (514MB zipped)
-  * [Download link](https://lilablobssc.blob.core.windows.net/iwildcam/iwildcam-2022-instance-masks.zip)
-    * Running `md5sum iwildcam-2022-instance-masks.zip` should produce `0ae1f437a2e4372af0ccd5def2bf7796`
-* iWildCam Remote Sensing Data (37GB zipped)
-  * [Download link](https://lilablobssc.blob.core.windows.net/iwildcam/iwildcam2020/iwildcam_rs_npy.tar.gz)
-    * Running `md5sum iwildcam_rs_npy.tar.gz` should produce `f25fbd47535a01139b0ef7b33b964269`
-* iNaturalist 2017 subset of images from our classes (2.2GB zipped)
-  * [Download link](https://lilablobssc.blob.core.windows.net/iwildcam/iwildcam2020/inaturalist_2017.tar.gz)
-    * Running `md5sum inaturalist_2017.tar.gz` should produce `bf9f18c0bc0169c243a8958d3705a0b9`
-* iNaturalist 2017 subset metadata
-  * [Download link](https://lilablobssc.blob.core.windows.net/iwildcam/iwildcam2020/inaturalist_2017_to_iwildcam_train.json)
-    * Running `md5sum inaturalist_2017_to_iwildcam_train.json` should produce `8664e8f16596995aae3a612d56e6426d`
-* iNaturalist 2018 subset of images from our classes (1.5GB zipped)
-  * [Download link](https://lilablobssc.blob.core.windows.net/iwildcam/iwildcam2020/inaturalist_2018.tar.gz)
-    * Running `md5sum inaturalist_2018.tar.gz` should produce `44c0d20abefb27ec1555bd451d4c8904`
-* iNaturalist 2018 subset metadata
-  * [Download link](https://lilablobssc.blob.core.windows.net/iwildcam/iwildcam2020/inaturalist_2018_to_iwildcam_train.json)
-    * Running `md5sum inaturalist_2018_to_iwildcam_train.json` should produce `dcdc925a494cb0e58daf9201eb69f595`
+Please see the [iWildCam 2022 page on lila.science](https://lila.science/datasets/iwildcam-2022/) for download links.
 
 ## Metadata Format
 


### PR DESCRIPTION
The dataset competition files are no longer accessible at the original links. This PR points to the iWildCam 2022 page on LILA.science where appropriate.